### PR TITLE
BUGFIX: Removing infinite loops

### DIFF
--- a/group_dumper.py
+++ b/group_dumper.py
@@ -55,9 +55,12 @@ try:
 except OSError:
 	pass # already exists
 
+new_timestamp = 0
+
 while end_mark not in messages_data:
 
-	data_text = {"messages[thread_fbids][" + str(talk) + "][offset]": str(offset), 
+	data_text = {"messages[thread_fbids][" + str(talk) + "][offset]": str(offset),
+	"messages[thread_fbids][" + str(talk) + "][timestamp]": str(new_timestamp),
 	"messages[thread_fbids][" + str(talk) + "][limit]": str(limit), 
 	"client": "web_messenger", 
 	"__user": "your_user_id", 
@@ -83,7 +86,10 @@ while end_mark not in messages_data:
 	json_data = json.loads(messages_data)
 	if json_data is not None and json_data['payload'] is not None:
 		try:
+			new_timestamp = json_data['payload']['actions'][0]['timestamp']
 			messages = messages + json_data['payload']['actions']
+			if 'end_of_history' in json_data['payload']:
+				break
 		except KeyError:
 			pass #no more messages
 	else:


### PR DESCRIPTION
Facebook's thread_info.php now _requires_ a timestamp in the headers. And it must be the same timestamp as the previous thread's last message.

Therefore, I'm adding the previous message's timestamp to the headers - without it, it will loop forever and only retrieve the previous request's data. This will mean it never terminates.

Additionally - I've added a breakpoint in the main loop. If "end_of_history" is in the payload, it terminates. For some reason, matching the string directly no longer works. 
